### PR TITLE
Fix some errors

### DIFF
--- a/classes/Content/class.xudfContentGUI.php
+++ b/classes/Content/class.xudfContentGUI.php
@@ -165,7 +165,7 @@ class xudfContentGUI extends xudfGUI
 
     protected function returnToParent(): void
     {
-        $this->dic->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $this->tree->getParentId($_GET['ref_id']));
+        $this->dic->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $this->tree->getParentId((int) $_GET['ref_id']));
         $this->dic->ctrl()->redirectByClass(ilRepositoryGUI::class);
     }
 

--- a/classes/Content/class.xudfContentGUI.php
+++ b/classes/Content/class.xudfContentGUI.php
@@ -177,8 +177,7 @@ class xudfContentGUI extends xudfGUI
                 break;
             case xudfSetting::REDIRECT_TO_ILIAS_OBJECT:
                 $ref_id = $this->getObject()->getSettings()->getRedirectValue();
-                $this->ctrl->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $ref_id);
-                $this->ctrl->redirectByClass(ilRepositoryGUI::class);
+                $this->ctrl->redirectToUrl('goto.php?target=' . ilObject::_lookupType((int) $ref_id,true) . '_' . $ref_id);
                 break;
             case xudfSetting::REDIRECT_TO_URL:
                 $url = $this->getObject()->getSettings()->getRedirectValue();

--- a/classes/Settings/class.xudfSettingsFormGUI.php
+++ b/classes/Settings/class.xudfSettingsFormGUI.php
@@ -30,7 +30,7 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
     public const F_MAIL_NOTIFICATION = 'mail_notification';
     public const F_ADDITIONAL_NOTIFICATION = 'additional_notification';
     public const F_REDIRECT_TYPE = 'redirect_type';
-    public const F_REF_ID = 'ref_id';
+    public const F_REF_ID = 'ref_id_redir';
     public const F_URL = 'url';
 
     protected static array $redirect_type_to_postvar


### PR DESCRIPTION
1. If Users click "back" when displaying the content, an error is displayes
2. If an ILIAS-object is selected as a redirect target and form is saved, another error appears

(The solution for 2 works for e.g. courses, groups, tests, but has some flaws for glossary, learning modules and contentpages)