### PR TITLE
R9 return to caller

### DIFF
--- a/classes/Content/class.xudfContentGUI.php
+++ b/classes/Content/class.xudfContentGUI.php
@@ -75,7 +75,7 @@ class xudfContentGUI extends xudfGUI
 
     protected function index(): void
     {
-        $has_open_fields = false;
+        $editable = $this->getObject()->getSettings()->getAlwaysEdit();
         $where = xudfContentElement::where(['obj_id' => $this->getObjId()]);
         if (!$_GET['edit'] && $where->count()) {
             $udf_values = $this->dic->user()->getUserDefinedData();
@@ -83,11 +83,11 @@ class xudfContentGUI extends xudfGUI
             /** @var xudfContentElement $element */
             foreach ($where->get() as $element) {
                 if (!$element->isSeparator() && !isset($udf_values["f_{$element->getUdfFieldId()}"])) {
-                    $has_open_fields = true;
+                    $editable = true;
                     break;
                 }
             }
-            if (!$has_open_fields) {
+            if (!$editable) {
                 // return button
                 $button = ilLinkButton::getInstance();
                 $button->setPrimary(true);
@@ -103,7 +103,7 @@ class xudfContentGUI extends xudfGUI
             }
         }
         $page_obj_gui = new xudfPageObjectGUI($this);
-        $form = new xudfContentFormGUI($this, $has_open_fields || $_GET['edit']);
+        $form = new xudfContentFormGUI($this, $editable || $_GET['edit']);
         $form->fillForm();
         $this->tpl->setContent($page_obj_gui->getHTML() . $form->getHTML());
     }

--- a/classes/Content/class.xudfContentGUI.php
+++ b/classes/Content/class.xudfContentGUI.php
@@ -169,21 +169,44 @@ class xudfContentGUI extends xudfGUI
         $this->dic->ctrl()->redirectByClass(ilRepositoryGUI::class);
     }
 
+    protected function returnToCaller(): void 
+    {
+	    if (isset($_SESSION['xudfreturn'])) {
+		    $backlink = $_SESSION['xudfreturn'];
+		    unset($_SESSION['xudfreturn']);
+		    ilUtil::redirect($backlink);
+	    } else {
+		    $this->ctrl->redirect($this);
+	    }
+    }
+    
     protected function redirectAfterSave(): void
     {
         switch ($this->getObject()->getSettings()->getRedirectType()) {
             case xudfSetting::REDIRECT_STAY_IN_FORM:
+                if (isset($_SESSION['xudfreturn'])) {
+		           unset($_SESSION['xudfreturn']);
+                }
                 $this->ctrl->redirect($this);
                 break;
             case xudfSetting::REDIRECT_TO_ILIAS_OBJECT:
+                if (isset($_SESSION['xudfreturn'])) {
+		           unset($_SESSION['xudfreturn']);
+	            }
                 $ref_id = $this->getObject()->getSettings()->getRedirectValue();
                 $this->ctrl->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $ref_id);
                 $this->ctrl->redirectByClass(ilRepositoryGUI::class);
                 break;
             case xudfSetting::REDIRECT_TO_URL:
+                if (isset($_SESSION['xudfreturn'])) {
+		           unset($_SESSION['xudfreturn']);
+	            }
                 $url = $this->getObject()->getSettings()->getRedirectValue();
                 $this->ctrl->redirectToURL($url);
-                break;
+                break; 
+            case xudfSetting::REDIRECT_TO_CALLER:
+	            $this->returnToCaller();
+	            break;
         }
     }
 }

--- a/classes/Content/class.xudfContentGUI.php
+++ b/classes/Content/class.xudfContentGUI.php
@@ -165,15 +165,15 @@ class xudfContentGUI extends xudfGUI
 
     protected function returnToParent(): void
     {
-        $this->dic->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $this->tree->getParentId($_GET['ref_id']));
+        $this->dic->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $this->tree->getParentId((int) $_GET['ref_id']));
         $this->dic->ctrl()->redirectByClass(ilRepositoryGUI::class);
     }
 
     protected function returnToCaller(): void 
     {
-	    if (isset($_SESSION['xudfreturn'])) {
-		    $backlink = $_SESSION['xudfreturn'];
-		    unset($_SESSION['xudfreturn']);
+	    if (ilSession::has('xudfreturn')) {
+		    $backlink = ilSession::get('xudfreturn');
+		    ilSession::clear('xudfreturn');
 		    ilUtil::redirect($backlink);
 	    } else {
 		    $this->ctrl->redirect($this);
@@ -184,22 +184,21 @@ class xudfContentGUI extends xudfGUI
     {
         switch ($this->getObject()->getSettings()->getRedirectType()) {
             case xudfSetting::REDIRECT_STAY_IN_FORM:
-                if (isset($_SESSION['xudfreturn'])) {
-		           unset($_SESSION['xudfreturn']);
+                if (ilSession::has('xudfreturn')) {
+		           ilSession::clear('xudfreturn');
                 }
                 $this->ctrl->redirect($this);
                 break;
             case xudfSetting::REDIRECT_TO_ILIAS_OBJECT:
-                if (isset($_SESSION['xudfreturn'])) {
-		           unset($_SESSION['xudfreturn']);
+                if (ilSession::has('xudfreturn')) {
+		           ilSession::clear('xudfreturn');
 	            }
                 $ref_id = $this->getObject()->getSettings()->getRedirectValue();
-                $this->ctrl->setParameterByClass(ilRepositoryGUI::class, 'ref_id', $ref_id);
-                $this->ctrl->redirectByClass(ilRepositoryGUI::class);
+                $this->ctrl->redirectToUrl('goto.php?target=' . ilObject::_lookupType((int) $ref_id,true) . '_' . $ref_id);
                 break;
             case xudfSetting::REDIRECT_TO_URL:
-                if (isset($_SESSION['xudfreturn'])) {
-		           unset($_SESSION['xudfreturn']);
+                if (ilSession::has('xudfreturn')) {
+		           ilSession::clear('xudfreturn');
 	            }
                 $url = $this->getObject()->getSettings()->getRedirectValue();
                 $this->ctrl->redirectToURL($url);

--- a/classes/Log/class.xudfLogTableGUI.php
+++ b/classes/Log/class.xudfLogTableGUI.php
@@ -115,8 +115,8 @@ class xudfLogTableGUI extends ilTable2GUI
     {
         // Not set (null) on first visit, false on reset filter, string if is set
         return (
-            isset($_SESSION["form_{$this->getId()}_$field_id"])
-            && $_SESSION["form_{$this->getId()}_$field_id"] !== false
+            ilsession::has("form_{$this->getId()}_$field_id")
+            && ilSession::get("form_{$this->getId()}_$field_id") !== false
         );
     }
 

--- a/classes/Settings/class.xudfSetting.php
+++ b/classes/Settings/class.xudfSetting.php
@@ -31,6 +31,7 @@ class xudfSetting extends ActiveRecord
     public const REDIRECT_STAY_IN_FORM = 'stay_in_form';
     public const REDIRECT_TO_ILIAS_OBJECT = 'to_ilias_object';
     public const REDIRECT_TO_URL = 'to_url';
+    public const REDIRECT_TO_CALLER = 'to_caller';
 
     public function getConnectorContainerName(): string
     {

--- a/classes/Settings/class.xudfSetting.php
+++ b/classes/Settings/class.xudfSetting.php
@@ -97,6 +97,16 @@ class xudfSetting extends ActiveRecord
      * @con_is_notnull   true
      */
     protected string $notification_name = "";
+    
+    /**
+     * @var bool
+     *
+     * @con_has_field    true
+     * @con_fieldtype    integer
+     * @con_length       1
+     * @con_is_notnull   false
+     */
+    protected $always_edit = false;
 
     public function getObjId(): int
     {

--- a/classes/Settings/class.xudfSettingsFormGUI.php
+++ b/classes/Settings/class.xudfSettingsFormGUI.php
@@ -38,7 +38,8 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
         = [
             xudfSetting::REDIRECT_STAY_IN_FORM => false,
             xudfSetting::REDIRECT_TO_ILIAS_OBJECT => self::F_REF_ID,
-            xudfSetting::REDIRECT_TO_URL => self::F_URL
+            xudfSetting::REDIRECT_TO_URL => self::F_URL,
+            xudfSetting::REDIRECT_TO_CALLER => false
         ];
 
     protected ilCtrl $ctrl;
@@ -115,6 +116,9 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
         $url_input = new ilTextInputGUI('', self::F_URL);
         $opt->addSubItem($url_input);
         $input->addOption($opt);
+
+        $opt = new ilRadioOption($this->pl->txt(xudfSetting::REDIRECT_TO_CALLER), xudfSetting::REDIRECT_TO_CALLER);
+        $input->addOption($opt); 
 
         $this->addItem($input);
 

--- a/classes/Settings/class.xudfSettingsFormGUI.php
+++ b/classes/Settings/class.xudfSettingsFormGUI.php
@@ -27,6 +27,7 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
     public const F_DESCRIPTION = 'description';
     public const F_ONLINE = 'online';
     public const F_SHOW_INFOTAB = 'show_infotab';
+    public const F_ALWAYS_EDIT = 'always_edit';
     public const F_MAIL_NOTIFICATION = 'mail_notification';
     public const F_ADDITIONAL_NOTIFICATION = 'additional_notification';
     public const F_REDIRECT_TYPE = 'redirect_type';
@@ -83,6 +84,11 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
         $input = new ilCheckboxInputGUI($this->pl->txt(self::F_SHOW_INFOTAB), self::F_SHOW_INFOTAB);
         $this->addItem($input);
 
+        // Configure Edit Mode
+        $input = new ilCheckboxInputGUI($this->pl->txt(self::F_ALWAYS_EDIT), self::F_ALWAYS_EDIT);
+        $input->setInfo($this->pl->txt(self::F_ALWAYS_EDIT . '_info'));
+        $this->addItem($input);
+
         // MAIL NOTIFICATION
         $input = new ilCheckboxInputGUI($this->pl->txt(self::F_MAIL_NOTIFICATION), self::F_MAIL_NOTIFICATION);
         $input->setInfo($this->pl->txt(self::F_MAIL_NOTIFICATION . '_info'));
@@ -122,6 +128,7 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
             self::F_DESCRIPTION => $this->parent_gui->getObject()->getDescription(),
             self::F_ONLINE => $this->xudfSetting->isOnline(),
             self::F_SHOW_INFOTAB => $this->xudfSetting->isShowInfoTab(),
+            self::F_ALWAYS_EDIT => $this->xudfSetting->getAlwaysEdit(),
             self::F_MAIL_NOTIFICATION => $this->xudfSetting->hasMailNotification(),
             self::F_ADDITIONAL_NOTIFICATION => $this->xudfSetting->getAdditionalNotification(),
             self::F_REDIRECT_TYPE => $this->xudfSetting->getRedirectType()
@@ -146,6 +153,7 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
 
         $this->xudfSetting->setIsOnline((bool) $this->getInput(self::F_ONLINE));
         $this->xudfSetting->setShowInfoTab((bool) $this->getInput(self::F_SHOW_INFOTAB));
+        $this->xudfSetting->setAlwaysEdit($this->getInput(self::F_ALWAYS_EDIT));
         $this->xudfSetting->setMailNotification((bool) $this->getInput(self::F_MAIL_NOTIFICATION));
         $this->xudfSetting->setAdditionalNotification($this->getInput(self::F_ADDITIONAL_NOTIFICATION));
         $this->xudfSetting->setRedirectType($this->getInput(self::F_REDIRECT_TYPE));

--- a/classes/Settings/class.xudfSettingsFormGUI.php
+++ b/classes/Settings/class.xudfSettingsFormGUI.php
@@ -116,10 +116,13 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
         $url_input = new ilTextInputGUI('', self::F_URL);
         $opt->addSubItem($url_input);
         $input->addOption($opt);
-
-        $opt = new ilRadioOption($this->pl->txt(xudfSetting::REDIRECT_TO_CALLER), xudfSetting::REDIRECT_TO_CALLER);
-        $input->addOption($opt); 
-
+        // only offer redirect to caller if referer contains a ref_id
+        // since some proxy scenarios do not pass the complete referer
+        if (isset($_SERVER['HTTP_REFERER']) && str_contains($_SERVER['HTTP_REFERER'],'ref_id')) {
+            $opt = new ilRadioOption($this->pl->txt(xudfSetting::REDIRECT_TO_CALLER), xudfSetting::REDIRECT_TO_CALLER);
+            $input->addOption($opt); 
+        }
+        
         $this->addItem($input);
 
         $this->addCommandButton(xudfSettingsGUI::CMD_UPDATE, $this->lng->txt('save'));

--- a/classes/Settings/class.xudfSettingsFormGUI.php
+++ b/classes/Settings/class.xudfSettingsFormGUI.php
@@ -31,7 +31,7 @@ class xudfSettingsFormGUI extends ilPropertyFormGUI
     public const F_MAIL_NOTIFICATION = 'mail_notification';
     public const F_ADDITIONAL_NOTIFICATION = 'additional_notification';
     public const F_REDIRECT_TYPE = 'redirect_type';
-    public const F_REF_ID = 'ref_id';
+    public const F_REF_ID = 'ref_id_target';
     public const F_URL = 'url';
 
     protected static array $redirect_type_to_postvar

--- a/classes/class.ilObjUdfEditorGUI.php
+++ b/classes/class.ilObjUdfEditorGUI.php
@@ -45,6 +45,21 @@ class ilObjUdfEditorGUI extends ilObjectPluginGUI
         parent::__construct($a_ref_id, $a_id_type, $a_parent_node_id);
         global $DIC;
         $this->dic = $DIC;
+        if (isset($_SERVER['HTTP_REFERER'])) {
+            $rref = 0;
+            $a_referer = explode('&',$_SERVER['HTTP_REFERER']);
+            if (count($a_referer)) {
+                foreach ($a_referer as $entry) {
+                    $a_entry = explode('=',$entry);
+                    if ($a_entry[0] == 'ref_id' && isset($a_entry[1])) {
+                        $rref = $a_entry[1];
+                    }
+                }
+            }
+            if ($rref != $this->ref_id && $rref!=0) {
+                $_SESSION['xudfreturn'] = $_SERVER['HTTP_REFERER'];
+            }
+        }
     }
 
     public function executeCommand(): void

--- a/classes/class.ilObjUdfEditorGUI.php
+++ b/classes/class.ilObjUdfEditorGUI.php
@@ -57,7 +57,7 @@ class ilObjUdfEditorGUI extends ilObjectPluginGUI
                 }
             }
             if ($rref != $this->ref_id && $rref!=0) {
-                $_SESSION['xudfreturn'] = $_SERVER['HTTP_REFERER'];
+                ilSession::set('xudfreturn',$_SERVER['HTTP_REFERER']);
             }
         }
     }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9,6 +9,8 @@ udf_field_type_2#:#Auswahlliste
 udf_field_type_3#:#Textbereich
 udf_field_type_51#:#Kaskadiert
 show_infotab#:#Tab "Info" anzeigen
+always_edit#:#Direkt bearbeitbar
+always_edit_info#:#Wenn alle Felder bereits gefüllt sind, entfällt das Einschalten des Bearbeitungsmodus 
 delete_confirmation_text#:#Sind Sie sicher, dass Sie folgendes Element löschen möchten?
 msg_successfully_deleted#:#Element erfolgreich gelöscht.
 msg_no_udfs#:#Auf dieser Plattform existieren noch keine Benutzerdefinierten Felder. Diese können in der Benutzeradministration erstellt werden.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -50,8 +50,8 @@ redirect_type_info#:#Wählen Sie hier aus, wohin ein Benutzer nach dem Speichern
 stay_in_form#:#Im Formular bleiben
 to_ilias_object#:#ILIAS-Objekt
 to_url#:#URL
+to_caller#:#Zurück zur aufrufenden Seite
 notification#:#Benachrichtigung
-
 notifications4plugin_actions#:#Aktionen
 notifications4plugin_add#:#Hinzugefügen
 notifications4plugin_add_notification#:#Benachrichtigung hinzufügen

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -36,7 +36,8 @@ fold_create_xudf#:#UdfEditor Erstellen
 grp_create_xudf#:#UdfEditor Erstellen
 root_create_xudf#:#UdfEditor Erstellen
 xudf_visible#:#Anzeigen: UdfEditor ist sichtbar
-xudf_read#:#Lesezugriff: Videos können angezeigt werden
+xudf_read#:#Lesezugriff: Inhalte können gesehen werden
+xudf_copy#:#Kopieren: UdfEditor kann kopiert werden
 xudf_write#:#Einstellungen bearbeiten: Einstellungen und Inhalte können bearbeitet werden
 xudf_delete#:#Löschen: Objekt kann gelöscht werden
 xudf_edit_permission#:#Rechteeinstellungen ändern: Rechteeinstellungen ändern

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -36,7 +36,8 @@ fold_create_xudf#:#Create UdfEditor
 grp_create_xudf#:#Create UdfEditor
 root_create_xudf#:#Create UdfEditor
 xudf_visible#:#Visible: UdfEditor is visible
-xudf_read#:#Read: User can watch the videos
+xudf_read#:#Read: User can see UdfEditor content
+xudf_copy#:#User can copy UdfEditor
 xudf_rep_robj_xudf_perm_upload#:#Upload: User can upload videos
 xudf_write#:#Edit Settings: User can edit content and settings of UdfEditor object
 xudf_delete#:#Delete: User can delete UdfEditor object

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9,6 +9,8 @@ udf_field_type_2#:#Selector
 udf_field_type_3#:#Textarea
 udf_field_type_51#:#Cascading
 show_infotab#:#Show Tab "Info"
+always_edit#:#Directly editable
+always_edit_info#:#Users dont need to turn on editmode if form is already filled completely
 delete_confirmation_text#:#Do you really want to delete the following element?
 msg_successfully_deleted#:#Element deleted successfully.
 msg_no_udfs#:#There are no user defined fields on this platform. These can be created in the user administration.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -37,7 +37,7 @@ grp_create_xudf#:#Create UdfEditor
 root_create_xudf#:#Create UdfEditor
 xudf_visible#:#Visible: UdfEditor is visible
 xudf_read#:#Read: User can see UdfEditor content
-xudf_copy#:#Copy: User can copy UdfEditor Object
+xudf_copy#:#Copy: User can copy UdfEditor object
 xudf_rep_robj_xudf_perm_upload#:#Upload: User can upload videos
 xudf_write#:#Edit Settings: User can edit content and settings of UdfEditor object
 xudf_delete#:#Delete: User can delete UdfEditor object

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -37,7 +37,7 @@ grp_create_xudf#:#Create UdfEditor
 root_create_xudf#:#Create UdfEditor
 xudf_visible#:#Visible: UdfEditor is visible
 xudf_read#:#Read: User can see UdfEditor content
-xudf_copy#:#User can copy UdfEditor
+xudf_copy#:#Copy: User can copy UdfEditor
 xudf_rep_robj_xudf_perm_upload#:#Upload: User can upload videos
 xudf_write#:#Edit Settings: User can edit content and settings of UdfEditor object
 xudf_delete#:#Delete: User can delete UdfEditor object

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -37,7 +37,7 @@ grp_create_xudf#:#Create UdfEditor
 root_create_xudf#:#Create UdfEditor
 xudf_visible#:#Visible: UdfEditor is visible
 xudf_read#:#Read: User can see UdfEditor content
-xudf_copy#:#Copy: User can copy UdfEditor
+xudf_copy#:#Copy: User can copy UdfEditor Object
 xudf_rep_robj_xudf_perm_upload#:#Upload: User can upload videos
 xudf_write#:#Edit Settings: User can edit content and settings of UdfEditor object
 xudf_delete#:#Delete: User can delete UdfEditor object

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -51,8 +51,8 @@ redirect_type_info#:#Choose here where a user should be redirected to after savi
 stay_in_form#:#stay in form
 to_ilias_object#:#to ILIAS object
 to_url#:#to URL
+to_caller#:#back to origin
 notification#:#Notification
-
 notifications4plugin_actions#:#Actions
 notifications4plugin_add#:#Add
 notifications4plugin_add_notification#:#Add notification

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 $id = "xudf";
-$version = "2.0.0";
+$version = "2.2.0";
 $ilias_min_version = '9.0';
 $ilias_max_version = '9.999';
 $responsible = "mbeym | mjansen";

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -50,3 +50,7 @@ xudfSetting::updateDB();
 \srag\Plugins\UdfEditor\Libs\Notifications4Plugin\Repository::getInstance()->installTables();
 \xudfSetting::updateDB();
 ?>
+<#8>
+<?php
+\xudfSetting::updateDB();
+?>


### PR DESCRIPTION
I added anoter option: If udf-editor is called from another object (including subtabs and so on), after saving users are returned to this place. 
We use this in a plugin, where the call to the udf editor is located inside a message. If a field that is required is not filled, uses can switch to an udf editor object, fill in their data and are returned to the place where they started.  